### PR TITLE
Po generation/comments support

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_generate_po_file_from_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_generate_po_file_from_metadata.rb
@@ -19,7 +19,7 @@ module Fastlane
           standard_files.append(key) unless SPECIAL_KEYS.include? File.basename(key, '.txt')
         end
         # Let the helper handle standard files
-        @po = Fastlane::Helper::GeneratePoFileMetadataHelper.add_standard_files_to_po(prefix, files: standard_files)
+        @po = Fastlane::Helper::GeneratePoFileMetadataHelper.add_standard_files_to_po(prefix, keys_to_comment_hash: @keys_to_comment_hash, files: standard_files)
 
         # Now handle release_notes.txt
         release_notes_file = Dir[File.join(@metadata_directory, 'release_notes.txt')][0]
@@ -64,7 +64,13 @@ module Fastlane
                                          # TODO: tell what files are missing
 
                                          # Warn if comments.json is not present
-                                         UI.message('comments.json files not present!') unless File.exist? File.join(value, 'comments.json')
+                                         keys_to_comment_hash_path = File.join(value, 'comments.json')
+                                         if File.exists? keys_to_comment_hash_path
+                                           # TODO: do not use eval
+                                           @keys_to_comment_hash = eval(File.read(keys_to_comment_hash_path))
+                                         else
+                                           UI.message('comments.json files not present!') unless File.exist? File.join(value, 'comments.json')
+                                         end
                                        end),
           FastlaneCore::ConfigItem.new(key: :release_version,
                                        env_name: "#{env_name_prefix}_RELEASE_VERSION",

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_generate_po_file_from_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_generate_po_file_from_metadata.rb
@@ -19,7 +19,7 @@ module Fastlane
           standard_files.append(key) unless SPECIAL_KEYS.include? File.basename(key, '.txt')
         end
         # Let the helper handle standard files
-        w        @po = Fastlane::Helper::GeneratePoFileMetadataHelper.add_standard_files_to_po(prefix, files: standard_files)
+        @po = Fastlane::Helper::GeneratePoFileMetadataHelper.add_standard_files_to_po(prefix, files: standard_files)
 
         # Now handle release_notes.txt
         release_notes_file = Dir[File.join(@metadata_directory, 'release_notes.txt')][0]
@@ -62,6 +62,9 @@ module Fastlane
                                          intersection = @txt_files_in_metadata_directory.intersection(REQUIRED_KEYS.to_set)
                                          UI.user_error!('One or more mandatory files are missing') unless intersection.length == REQUIRED_KEYS.to_set.length
                                          # TODO: tell what files are missing
+
+                                         # Warn if comments.json is not present
+                                         UI.message('comments.json files not present!') unless File.exist? File.join(value, 'comments.json')
                                        end),
           FastlaneCore::ConfigItem.new(key: :release_version,
                                        env_name: "#{env_name_prefix}_RELEASE_VERSION",

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_generate_po_file_from_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_generate_po_file_from_metadata.rb
@@ -19,7 +19,7 @@ module Fastlane
           standard_files.append(key) unless SPECIAL_KEYS.include? File.basename(key, '.txt')
         end
         # Let the helper handle standard files
-        @po = Fastlane::Helper::GeneratePoFileMetadataHelper.add_standard_file_to_po(prefix, files: standard_files)
+        w        @po = Fastlane::Helper::GeneratePoFileMetadataHelper.add_standard_files_to_po(prefix, files: standard_files)
 
         # Now handle release_notes.txt
         release_notes_file = Dir[File.join(@metadata_directory, 'release_notes.txt')][0]
@@ -68,7 +68,7 @@ module Fastlane
                                        description: 'The release version of the app (to use to mark the release notes)',
                                        verify_block: proc do |value|
                                          UI.user_error!("No release version for AnGeneratePoFileFromMetadataAction given, pass using `release_version: 'version'`") unless value && (!value.empty?)
-                                       end)
+                                       end),
 
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/generate_po_file_from_metadata_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/generate_po_file_from_metadata_helper.rb
@@ -1,4 +1,5 @@
 require 'gettext/po'
+require 'gettext/po_entry'
 
 module Fastlane
   module Helper
@@ -8,12 +9,17 @@ module Fastlane
 
       # Return a GetText::PO object
       # standard_keys is the list of files
-      def self.add_standard_file_to_po(prefix, files: [])
+      def self.add_standard_files_to_po(prefix, files: [])
         po_obj = GetText::PO.new
         files.each do |file_name|
           msgid = File.open(file_name).read
           msgctxt = "#{prefix}_#{File.basename(file_name, '.txt')}"
-          po_obj[msgctxt, msgid] = ''
+          entry = GetText::POEntry.new(:msgctxt)
+          entry.msgid = msgid
+          entry.msgctxt = msgctxt
+          entry.msgstr = ''
+          # entry.translator_comment = "It's the translator comment."
+          po_obj[entry.msgctxt, entry.msgid] = entry
         end
         po_obj
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/generate_po_file_from_metadata_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/generate_po_file_from_metadata_helper.rb
@@ -9,15 +9,18 @@ module Fastlane
 
       # Return a GetText::PO object
       # standard_keys is the list of files
-      def self.add_standard_files_to_po(prefix, files: [])
+      def self.add_standard_files_to_po(prefix, keys_to_comment_hash: Hash, files: [])
         po_obj = GetText::PO.new
         files.each do |file_name|
-          msgid = File.open(file_name).read
-          msgctxt = "#{prefix}_#{File.basename(file_name, '.txt')}"
+          key = File.basename(file_name, '.txt')
           entry = GetText::POEntry.new(:msgctxt)
-          entry.msgid = msgid
-          entry.msgctxt = msgctxt
+          entry.msgid = File.open(file_name).read
+          entry.msgctxt = "#{prefix}_#{File.basename(file_name, '.txt')}"
           entry.msgstr = ''
+          # if we have comment whose key matches our translation key
+          if keys_to_comment_hash.key? key.to_sym
+            entry.translator_comment = ".translators: #{keys_to_comment_hash[key.to_sym]}"
+          end
           # entry.translator_comment = "It's the translator comment."
           po_obj[entry.msgctxt, entry.msgid] = entry
         end

--- a/spec/android_generate_po_file_from_metadata_test.rb
+++ b/spec/android_generate_po_file_from_metadata_test.rb
@@ -1,16 +1,22 @@
 require 'spec_helper'
+require 'json'
 
 describe Fastlane::Actions::AndroidGeneratePoFileFromMetadataAction do
   it 'create the .po files based on the .txt files in metadata_directory' do
     in_tmp_dir do |dir|
       required_keys = %w[description keywords name release_notes release_notes_previous].freeze
-      # required_files = required_keys.map { |key| File.join(dir, "#{key}.txt") }
 
       # For each key create a key.txt file whose content is "value key"
+      # Also fill up the key_to_comment_hash
+      key_to_comment_hash = {}
       required_keys.each do |key|
         write_to = File.join(dir, "#{key}.txt")
         File.write(write_to, "value #{key}")
+        key_to_comment_hash[key] = "Comment for #{key}"
       end
+
+      comments_path = File.join(dir, 'comments.json')
+      File.write(comments_path, JSON.pretty_generate(key_to_comment_hash))
 
       output_po_path = File.join(dir, 'PlayStoreStrings.po')
 
@@ -20,14 +26,17 @@ describe Fastlane::Actions::AndroidGeneratePoFileFromMetadataAction do
       )
 
       expected = <<~PO
+        # .translators: Comment for keywords
         msgctxt "play_store_keywords"
         msgid "value keywords"
         msgstr ""
 
+        # .translators: Comment for name
         msgctxt "play_store_name"
         msgid "value name"
         msgstr ""
 
+        # .translators: Comment for description
         msgctxt "play_store_description"
         msgid "value description"
         msgstr ""
@@ -49,3 +58,4 @@ describe Fastlane::Actions::AndroidGeneratePoFileFromMetadataAction do
     end
   end
 end
+


### PR DESCRIPTION
This PR adds support for a `comments.json` file:
```
{
  "description": "Comment for description",
  "keywords": "Comment for keywords",
  "name": "Comment for name",
}
```

The values will be added to the final po. resulting in
```
# .translators: Comment for name
msgctxt "play_store_name"
msgid "value name"
msgstr ""

```

