### PR TITLE
Po generation/part 3

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_generate_po_file_from_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_generate_po_file_from_metadata.rb
@@ -66,9 +66,9 @@ module Fastlane
             key: :metadata_directory,
             env_name: "#{env_name_prefix}_METADATA_DIRECTORY",
             description: 'The path containing the .txt files',
+            optional: false,
             is_string: true,
             verify_block: proc do |value|
-              UI.user_error!("No metadata_directory path for `AnGeneratePoFileFromMetadataAction` given, pass using `metadata_directory: 'directory'`") unless value && !value.empty?
               UI.user_error!("Couldn't find path '#{value}'") unless Dir.exist?(value)
 
               required_keys_exist, message = Fastlane::Helper::GeneratePoFileMetadataHelper.do_required_keys_exist(metadata_folder: value, required_keys: REQUIRED_KEYS)
@@ -79,9 +79,7 @@ module Fastlane
             key: :release_version,
             env_name: "#{env_name_prefix}_RELEASE_VERSION",
             description: 'The release version of the app (to use to mark the release notes)',
-            verify_block: proc do |value|
-              UI.user_error!("No release version for `AnGeneratePoFileFromMetadataAction` given, pass using `release_version: 'version'`") unless value && !value.empty?
-            end
+            optional: false
           ),
           FastlaneCore::ConfigItem.new(
             key: :other_sources,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_generate_po_file_from_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_generate_po_file_from_metadata.rb
@@ -61,9 +61,9 @@ module Fastlane
             key: :metadata_directory,
             env_name: "#{env_name_prefix}_METADATA_DIRECTORY",
             description: 'The path containing the .txt files ',
+            optional: false,
             is_string: true,
             verify_block: proc do |value|
-              UI.user_error!("No metadata_directory path for `IosGeneratePoFileFromMetadataAction` given, pass using `metadata_directory: 'directory'`") unless value && !value.empty?
               UI.user_error!("Couldn't find path '#{value}'") unless Dir.exist?(value)
 
               required_keys_exist, message = Fastlane::Helper::GeneratePoFileMetadataHelper.do_required_keys_exist(metadata_folder: value, required_keys: REQUIRED_KEYS)
@@ -74,9 +74,7 @@ module Fastlane
             key: :release_version,
             env_name: "#{env_name_prefix}_RELEASE_VERSION",
             description: 'The release version of the app (to use to mark the release notes)',
-            verify_block: proc do |value|
-              UI.user_error!("No release version for `IosGeneratePoFileFromMetadataAction given`, pass using `release_version: 'version'`") unless value && !value.empty?
-            end
+            optional: false
           ),
           FastlaneCore::ConfigItem.new(
             key: :other_sources,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/generate_po_file_from_metadata_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/generate_po_file_from_metadata_helper.rb
@@ -12,6 +12,7 @@ module Fastlane
       def initialize(keys_to_comment_hash:, other_sources:, metadata_directory:, release_version:, prefix: '')
         @po = PoExtended.new(:msgctxt)
         @keys_to_comment_hash = keys_to_comment_hash.merge(KNOWN_OPTIONAL_KEYS_TO_COMMENT_HASH)
+        @regexp_to_comment_hash = @keys_to_comment_hash.filter { |k| k.instance_of?(Regexp) }
         @other_sources = other_sources
         @metadata_directory = metadata_directory
         @release_version = release_version
@@ -68,7 +69,7 @@ module Fastlane
         translator_prefix = '.translators:'
         (return "#{translator_prefix} #{@keys_to_comment_hash[key.to_sym]}") if (@keys_to_comment_hash.key? key.to_sym) && (!@keys_to_comment_hash[key.to_sym].nil? && !@keys_to_comment_hash[key.to_sym].empty?)
 
-        @keys_to_comment_hash.filter { |k| k.instance_of?(Regexp) }.each do |keytemp, value|
+        @regexp_to_comment_hash.each do |keytemp, value|
           regexp = Regexp.new(keytemp)
           next unless key.match?(regexp)
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/generate_po_file_from_metadata_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/generate_po_file_from_metadata_helper.rb
@@ -66,19 +66,16 @@ module Fastlane
 
       def comment(key:)
         translator_prefix = '.translators:'
-        if (@keys_to_comment_hash.key? key.to_sym) && (!@keys_to_comment_hash[key.to_sym].nil? && !@keys_to_comment_hash[key.to_sym].empty?)
-          return "#{translator_prefix} #{@keys_to_comment_hash[key.to_sym]}"
-        else
-          @keys_to_comment_hash.filter { |k| k.instance_of?(Regexp) }.each do |keytemp, value|
+        (return "#{translator_prefix} #{@keys_to_comment_hash[key.to_sym]}") if (@keys_to_comment_hash.key? key.to_sym) && (!@keys_to_comment_hash[key.to_sym].nil? && !@keys_to_comment_hash[key.to_sym].empty?)
 
-            regexp = Regexp.new(keytemp)
-            next unless key.match(regexp)
+        @keys_to_comment_hash.filter { |k| k.instance_of?(Regexp) }.each do |keytemp, value|
+          regexp = Regexp.new(keytemp)
+          next unless key.match?(regexp)
 
-            shot_number = key.match(regexp).captures[0]
-            return "#{translator_prefix} #{format(value, shot: shot_number)}"
-          end
+          shot_number = key.match(regexp).captures[0]
+          return "#{translator_prefix} #{format(value, shot: shot_number)}"
         end
-        ''
+        return ''
       end
 
       def add_standard_files_to_po(files: [])

--- a/spec/android_generate_po_file_from_metadata_spec.rb
+++ b/spec/android_generate_po_file_from_metadata_spec.rb
@@ -55,12 +55,12 @@ describe Fastlane::Actions::AndroidGeneratePoFileFromMetadataAction do
         msgid "value full_description"
         msgstr ""
 
-        # .translators: Description for the first app store image
+        # .translators: Text that will be used to decorate the screenshot 1
         msgctxt "play_store_promo_screenshot_1"
         msgid "What you are reading is coming from another source"
         msgstr ""
 
-        # .translators: Description for the second app store image
+        # .translators: Text that will be used to decorate the screenshot 2
         msgctxt "play_store_promo_screenshot_2"
         msgid "What you are reading is coming from another source again"
         msgstr ""
@@ -95,6 +95,8 @@ describe Fastlane::Actions::AndroidGeneratePoFileFromMetadataAction do
         msgid "value title"
         msgstr ""
       PO
+      File.write('/Users/juza/Projects/release-toolkit/Test/po222', File.read(output_po_path))
+      File.write('/Users/juza/Projects/release-toolkit/Test/expected222', expected)
       expect(File.read(output_po_path)).to eq(expected)
     end
   end
@@ -177,12 +179,12 @@ describe Fastlane::Actions::AndroidGeneratePoFileFromMetadataAction do
         msgid "value full_description"
         msgstr ""
 
-        # .translators: Description for the first app store image
+        # .translators: Text that will be used to decorate the screenshot 1
         msgctxt "play_store_promo_screenshot_1"
         msgid "What you are reading is coming from another source"
         msgstr ""
 
-        # .translators: Description for the second app store image
+        # .translators: Text that will be used to decorate the screenshot 2
         msgctxt "play_store_promo_screenshot_2"
         msgid "What you are reading is coming from another source again"
         msgstr ""
@@ -217,7 +219,8 @@ describe Fastlane::Actions::AndroidGeneratePoFileFromMetadataAction do
         msgid "value title"
         msgstr ""
       PO
-
+      File.write('/Users/juza/Projects/release-toolkit/Test/po1', File.read(output_po_path))
+      File.write('/Users/juza/Projects/release-toolkit/Test/expected1', expected)
       expect(File.read(output_po_path)).to eq(expected)
     end
   end

--- a/spec/android_generate_po_file_from_metadata_spec.rb
+++ b/spec/android_generate_po_file_from_metadata_spec.rb
@@ -95,8 +95,6 @@ describe Fastlane::Actions::AndroidGeneratePoFileFromMetadataAction do
         msgid "value title"
         msgstr ""
       PO
-      File.write('/Users/juza/Projects/release-toolkit/Test/po222', File.read(output_po_path))
-      File.write('/Users/juza/Projects/release-toolkit/Test/expected222', expected)
       expect(File.read(output_po_path)).to eq(expected)
     end
   end
@@ -219,8 +217,6 @@ describe Fastlane::Actions::AndroidGeneratePoFileFromMetadataAction do
         msgid "value title"
         msgstr ""
       PO
-      File.write('/Users/juza/Projects/release-toolkit/Test/po1', File.read(output_po_path))
-      File.write('/Users/juza/Projects/release-toolkit/Test/expected1', expected)
       expect(File.read(output_po_path)).to eq(expected)
     end
   end

--- a/spec/ios_generate_po_file_from_metadata_spec.rb
+++ b/spec/ios_generate_po_file_from_metadata_spec.rb
@@ -66,12 +66,12 @@ describe Fastlane::Actions::IosGeneratePoFileFromMetadataAction do
         msgid "value name"
         msgstr ""
 
-        # .translators: Description for the first app store image
+        # .translators: Text that will be used to decorate the screenshot 1
         msgctxt "app_store_promo_screenshot_1"
         msgid "What you are reading is coming from another source"
         msgstr ""
 
-        # .translators: Description for the second app store image
+        # .translators: Text that will be used to decorate the screenshot 2
         msgctxt "app_store_promo_screenshot_2"
         msgid "What you are reading is coming from another source again"
         msgstr ""
@@ -172,12 +172,12 @@ describe Fastlane::Actions::IosGeneratePoFileFromMetadataAction do
         msgid "value name"
         msgstr ""
 
-        # .translators: Description for the first app store image
+        # .translators: Text that will be used to decorate the screenshot 1
         msgctxt "app_store_promo_screenshot_1"
         msgid "What you are reading is coming from another source"
         msgstr ""
 
-        # .translators: Description for the second app store image
+        # .translators: Text that will be used to decorate the screenshot 2
         msgctxt "app_store_promo_screenshot_2"
         msgid "What you are reading is coming from another source again"
         msgstr ""


### PR DESCRIPTION
Use a single regular expression to handle the simple case when call sites do not provide description for screenshots that might exist in `metadata_folder`.

> Unlike for the REQUIRED_KEYS_TO_COMMENT_HASH which will be the same for all apps, those should probably be provided by the call site instead of being hardcoded in release-toolkit, since those optional keys will come from other_sources and not be really standardized
> Though as a future improvement, I'd also suggest to make those *_KEYS_TO_COMMENT_HASH constants use Regular Expressions matching instead of hardcoded string, so that we can imagine providing a mapping with something probably like /^screenshots-(.*)/ => 'Text that will be used to decorate the screenshot \1' that could work for all screeenshots-*.txt files found in other_sources by default.

The above quote [is part of this discussion](https://github.com/wordpress-mobile/release-toolkit/pull/414#discussion_r991435242)
